### PR TITLE
Drop Ruby 2.5 from test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ rvm:
 # note that jruby cannot be supported because it doesn't support C extensions and this gem doesn't support
 # an alternative to oj, which is a C extension
 # also: truffleruby is included explicitly in the job matrix
-- ruby-2.5
 - ruby-2.6
 - ruby-2.7
 - ruby-3.0

--- a/lib/aganakti/version.rb
+++ b/lib/aganakti/version.rb
@@ -2,5 +2,5 @@
 
 module Aganakti
   # The version number.
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end


### PR DESCRIPTION
Ruby 2.5 reached its EOL on 2021-04-05