### PR TITLE
Omit options from client when they are not provided by the gem user

### DIFF
--- a/lib/aganakti.rb
+++ b/lib/aganakti.rb
@@ -111,17 +111,22 @@ module Aganakti
       Ethon::Curl.version
     ].compact.join(' ')
 
+    # Form the options for Aganakti::Client to pass to Typhoeus
+    client_options = {
+      accept_encoding: '', # allow libcurl to determine its supported compression
+      headers:         {
+        'Connection' => 'keep-alive',
+        'User-Agent' => user_agent
+      },
+      tcp_keeppalive:  true
+    }
+
+    client_options[:connecttimeout] = options[:connect_timeout] if options.key?(:connect_timeout)
+    client_options[:cainfo] = options[:tls_ca_certificate_bundle] if options.key?(:tls_ca_certificate_bundle)
+    client_options[:timeout] = options[:timeout] if options.key?(:timeout)
+
     # Finally construct our client
-    Client.new uri,
-               accept_encoding: '', # allow libcurl to determine its supported compression
-               cainfo:          options[:tls_ca_certificate_bundle],
-               connecttimeout:  options[:connect_timeout],
-               headers:         {
-                 'Connection' => 'keep-alive',
-                 'User-Agent' => user_agent
-               },
-               tcp_keepalive:   true,
-               timeout:         options[:timeout]
+    Client.new uri, **client_options
   end
   module_function :new
 end

--- a/lib/aganakti.rb
+++ b/lib/aganakti.rb
@@ -122,8 +122,8 @@ module Aganakti
     }
 
     client_options[:connecttimeout] = options[:connect_timeout] if options.key?(:connect_timeout)
-    client_options[:cainfo] = options[:tls_ca_certificate_bundle] if options.key?(:tls_ca_certificate_bundle)
-    client_options[:timeout] = options[:timeout] if options.key?(:timeout)
+    client_options[:cainfo]         = options[:tls_ca_certificate_bundle] if options.key?(:tls_ca_certificate_bundle)
+    client_options[:timeout]        = options[:timeout] if options.key?(:timeout)
 
     # Finally construct our client
     Client.new uri, **client_options

--- a/lib/aganakti/version.rb
+++ b/lib/aganakti/version.rb
@@ -2,5 +2,5 @@
 
 module Aganakti
   # The version number.
-  VERSION = '0.1.1'
+  VERSION = '1.0.0'
 end

--- a/spec/lib/aganakti_spec.rb
+++ b/spec/lib/aganakti_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe Aganakti do
     %w[HTTP HTTPS].each do |proto|
       context "with a #{proto} URI", :stubbed_client do
         let(:url) { "#{proto.downcase}://druidserver/query" }
+
         let(:default_options) do
           {
             accept_encoding: '',

--- a/spec/lib/aganakti_spec.rb
+++ b/spec/lib/aganakti_spec.rb
@@ -40,17 +40,15 @@ RSpec.describe Aganakti do
     %w[HTTP HTTPS].each do |proto|
       context "with a #{proto} URI", :stubbed_client do
         let(:url) { "#{proto.downcase}://druidserver/query" }
-
-        it 'created a client with accept_encoding = ""' do
-          described_class.new(url)
-
-          expect(Aganakti::Client).to have_received(:new).with(anything, hash_including(accept_encoding: ''))
-        end
-
-        it 'created a client with the Connection header set to "keep-alive"' do
-          described_class.new(url)
-
-          expect(Aganakti::Client).to have_received(:new).with(anything, hash_including(headers: hash_including('Connection' => 'keep-alive')))
+        let(:default_options) do
+          {
+            accept_encoding: '',
+            headers:         {
+              'Connection' => 'keep-alive',
+              'User-Agent' => %r{\AAganakti/[\w.]+ Typhoeus/[\w.]+ Ruby/[\w.]+ libcurl/.*}
+            },
+            tcp_keeppalive:  true
+          }
         end
 
         it 'created a client with the expected URL' do
@@ -59,33 +57,10 @@ RSpec.describe Aganakti do
           expect(Aganakti::Client).to have_received(:new).with(url, anything)
         end
 
-        it 'created a client with the User-Agent header set to the default' do
+        it 'creates a client with the default options only' do
           described_class.new(url)
 
-          expect(Aganakti::Client).to have_received(:new).with(anything, hash_including(
-                                                                           headers: hash_including(
-                                                                             # not matching beyond libcurl because it depends on the built libcurl
-                                                                             'User-Agent' => %r{\AAganakti/[\w.]+ Typhoeus/[\w.]+ Ruby/[\w.]+ libcurl/.*}
-                                                                           )
-                                                                         ))
-        end
-
-        it 'created a client without cainfo' do
-          described_class.new(url)
-
-          expect(Aganakti::Client).to have_received(:new).with(anything, hash_including(cainfo: nil))
-        end
-
-        it 'created a client without connecttimeout' do
-          described_class.new(url)
-
-          expect(Aganakti::Client).to have_received(:new).with(anything, hash_including(connecttimeout: nil))
-        end
-
-        it 'created a client without timeout' do
-          described_class.new(url)
-
-          expect(Aganakti::Client).to have_received(:new).with(anything, hash_including(timeout: nil))
+          expect(Aganakti::Client).to have_received(:new).with(url, default_options)
         end
 
         it "doesn't raise an error" do


### PR DESCRIPTION
```
irb(main):083* Aganakti::Client.new(uri,   accept_encoding: '', # allow libcurl to determine its supported compression
irb(main):084*                cainfo:          options[:tls_ca_certificate_bundle],
irb(main):085*                connecttimeout:  options[:connect_timeout],
irb(main):086*                headers:         {
irb(main):087*                  'Connection' => 'keep-alive',
irb(main):088*                  'User-Agent' => user_agent
irb(main):089*                },
irb(main):090*                tcp_keepalive:   true,
irb(main):091> timeout:         options[:timeout]).query('select * from fact_downloads limit 1').result
(irb):91:in `<main>': cURL error 60: SSL peer certificate or SSH remote key was not OK (Aganakti::QueryError)
```

This is because when `options` does not contain `tls_ca_certificate_bundle`, the `cainfo` option for the client is set to `null`. However this causes the client to skip the default certificate trust chain instead of defaulting to it. From an environment where the default chain trusts the druid server's certificate, omitting the option allows the request to work as normal. 

```
irb(main):092* Aganakti::Client.new(uri,   accept_encoding: '', # allow libcurl to determine its supported compression
irb(main):093*                connecttimeout:  options[:connect_timeout],
irb(main):094*                headers:         {
irb(main):095*                  'Connection' => 'keep-alive',
irb(main):096*                  'User-Agent' => user_agent
irb(main):097*                },
irb(main):098*                tcp_keepalive:   true,
irb(main):099> timeout:         options[:timeout]).query('select * from fact_downloads limit 1').result
=>
#<ActiveRecord::Result:0x00007f5ffc770d90
 @column_types={},
 @columns=
  ["__time",

```

This pull request updates the logic to make the `tls_ca_certificate_bundle` option truly optional by omitting it when it is not provided.