### PR TITLE
Add with_windowing setting method to set enableWindowing

### DIFF
--- a/lib/aganakti.rb
+++ b/lib/aganakti.rb
@@ -118,7 +118,7 @@ module Aganakti
         'Connection' => 'keep-alive',
         'User-Agent' => user_agent
       },
-      tcp_keeppalive:  true
+      tcp_keepalive:  true
     }
 
     client_options[:connecttimeout] = options[:connect_timeout] if options.key?(:connect_timeout)

--- a/lib/aganakti/query.rb
+++ b/lib/aganakti/query.rb
@@ -17,9 +17,11 @@ module Aganakti
       with_approximate_count_distinct
       with_approximate_top_n
       with_cache
+      with_windowing
       without_approximate_count_distinct
       without_approximate_top_n
       without_cache
+      without_windowing
     ].freeze
     private_constant :BOOL_SETTING_METHODS
 
@@ -156,6 +158,13 @@ module Aganakti
     #   @raise [Aganakti::QueryAlreadyExecutedError] if the query has already been executed
 
     ##
+    # @!method with_windowing
+    #  Asks Druid to enable windowing functions for this query.
+    #
+    #  @return [self] this instance, for chaining
+    #  @return [Aganakti::QueryAlreadyExecutedError] if the query has already been executed
+
+    ##
     # @!method without_approximate_count_distinct
     #   Asks Druid not to use an approximate cardinality algorithm for +COUNT(DISTINCT foo)+.
     #
@@ -176,6 +185,14 @@ module Aganakti
     #
     #   @return [self] this instance, for chaining
     #   @raise [Aganakti::QueryAlreadyExecutedError] if the query has already been executed
+    #
+
+    ##
+    # @!method without_windowing
+    #  Asks Druid to disable windowing functions for this query.
+    #
+    #  @return [self] this instance, for chaining
+    #  @return [Aganakti::QueryAlreadyExecutedError] if the query has already been executed
 
     # @!endgroup
 

--- a/lib/aganakti/query.rb
+++ b/lib/aganakti/query.rb
@@ -162,7 +162,7 @@ module Aganakti
     #  Asks Druid to enable windowing functions for this query.
     #
     #  @return [self] this instance, for chaining
-    #  @return [Aganakti::QueryAlreadyExecutedError] if the query has already been executed
+    #  @raise [Aganakti::QueryAlreadyExecutedError] if the query has already been executed
 
     ##
     # @!method without_approximate_count_distinct
@@ -192,7 +192,7 @@ module Aganakti
     #  Asks Druid to disable windowing functions for this query.
     #
     #  @return [self] this instance, for chaining
-    #  @return [Aganakti::QueryAlreadyExecutedError] if the query has already been executed
+    #  @raise [Aganakti::QueryAlreadyExecutedError] if the query has already been executed
 
     # @!endgroup
 

--- a/lib/aganakti/query/building.rb
+++ b/lib/aganakti/query/building.rb
@@ -20,6 +20,7 @@ module Aganakti
       # @return [Hash] the query context
       def query_context
         {
+          enableWindowing:             @windowing,
           priority:                    @priority,
           sqlQueryId:                  @qid,
           sqlTimeZone:                 @time_zone,

--- a/lib/aganakti/version.rb
+++ b/lib/aganakti/version.rb
@@ -2,5 +2,5 @@
 
 module Aganakti
   # The version number.
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/spec/lib/aganakti/query_spec.rb
+++ b/spec/lib/aganakti/query_spec.rb
@@ -313,10 +313,12 @@ RSpec.describe Aganakti::Query do
     with_approximate_count_distinct:    [:useApproximateCountDistinct, true],
     with_approximate_top_n:             [:useApproximateTopN, true],
     with_cache:                         [:useCache, true],
+    with_windowing:                     [:enableWindowing, true],
     with_priority:                      [:priority, 1],
     without_approximate_count_distinct: [:useApproximateCountDistinct, false],
     without_approximate_top_n:          [:useApproximateTopN, false],
-    without_cache:                      [:useCache, false]
+    without_cache:                      [:useCache, false],
+    without_windowing:                  [:enableWindowing, false]
   }.each_pair do |meth, (json_key, test_arg)|
     # Pick the other method to call to check we don't clobber it
     if %i[with_approximate_count_distinct without_approximate_count_distinct].include?(meth)

--- a/spec/lib/aganakti_spec.rb
+++ b/spec/lib/aganakti_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Aganakti do
               'Connection' => 'keep-alive',
               'User-Agent' => %r{\AAganakti/[\w.]+ Typhoeus/[\w.]+ Ruby/[\w.]+ libcurl/.*}
             },
-            tcp_keeppalive:  true
+            tcp_keepalive:  true
           }
         end
 


### PR DESCRIPTION
Window functions require `enableWindowing` to be set in the query context to be executed. Otherwise we get

```
Aganakti::QueryError (druidException: The query contains window functions; To run these window functions, specify [enableWindowing] in query context. (line [1], column [37]))
``` 

This PR adds `with_windowing` and `without_windowing` to accomplish this.