### PR TITLE
Add a with_context method to allow setting of any arbitrary context keys

### DIFF
--- a/aganakti.gemspec
+++ b/aganakti.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rspec', '~> 2.2.0'
   spec.add_development_dependency 'simplecov',     '~> 0.21.2'
   spec.add_development_dependency 'solargraph',    '~> 0.40.4'
-  spec.add_development_dependency 'stub_server',   '~> 0.5.0'
+  spec.add_development_dependency 'stub_server',   '~> 0.7.0'
   spec.add_development_dependency 'webrick',       '~> 1.7.0'
   spec.add_development_dependency 'yard',          '~> 0.9.26'
 end

--- a/lib/aganakti/query.rb
+++ b/lib/aganakti/query.rb
@@ -48,8 +48,10 @@ module Aganakti
       @approximate_count_distinct = nil
       @approximate_top_n          = nil
       @cache                      = nil
+      @custom_context             = {}
       @priority                   = nil
       @time_zone                  = nil
+      @windowing                  = nil
     end
 
     ##
@@ -114,6 +116,32 @@ module Aganakti
                   else
                     Integer(priority)
                   end
+
+      self
+    end
+
+    ##
+    # Merges arbitrary context parameters for this query. This allows you to pass
+    # any Druid context parameters that aren't explicitly supported by other methods.
+    #
+    # Built-in methods (+with_cache+, +with_priority+, +in_time_zone+, etc.) always take
+    # precedence over values set by +with_context+, regardless of call order. This ensures
+    # that explicit, documented methods cannot be accidentally overridden.
+    #
+    # @param context_hash [Hash] hash of context parameters to merge
+    # @return [self] this instance, for chaining
+    # @raise [Aganakti::QueryAlreadyExecutedError] if the query has already been executed
+    #
+    # @example Set custom context parameters
+    #   query.with_context(maxScatterGatherBytes: 1_000_000, timeout: 30000)
+    #
+    # @example Built-in methods always take precedence
+    #   query.with_cache.with_context(useCache: false) # useCache will be true
+    #   query.with_context(useCache: false).with_cache # useCache will be true
+    def with_context(context_hash)
+      raise QueryAlreadyExecutedError, 'with_context cannot be set because the query has already been executed' if executed?
+
+      @custom_context.merge!(context_hash.transform_keys(&:to_sym))
 
       self
     end

--- a/lib/aganakti/query/building.rb
+++ b/lib/aganakti/query/building.rb
@@ -19,15 +19,17 @@ module Aganakti
       #
       # @return [Hash] the query context
       def query_context
-        {
-          enableWindowing:             @windowing,
-          priority:                    @priority,
-          sqlQueryId:                  @qid,
-          sqlTimeZone:                 @time_zone,
-          useApproximateCountDistinct: @approximate_count_distinct,
-          useApproximateTopN:          @approximate_top_n,
-          useCache:                    @cache
-        }.compact.freeze
+        (@custom_context || {}).merge(
+          {
+            enableWindowing:             @windowing,
+            priority:                    @priority,
+            sqlQueryId:                  @qid,
+            sqlTimeZone:                 @time_zone,
+            useApproximateCountDistinct: @approximate_count_distinct,
+            useApproximateTopN:          @approximate_top_n,
+            useCache:                    @cache
+          }
+        ).compact.freeze
       end
 
       ##

--- a/spec/lib/aganakti/query_spec.rb
+++ b/spec/lib/aganakti/query_spec.rb
@@ -420,4 +420,251 @@ RSpec.describe Aganakti::Query do
       end
     end
   end
+
+  describe '#with_context', :stubbed_request do
+    before do
+      allow(Oj).to receive(:dump).and_call_original.once
+    end
+
+    context 'when setting custom context parameters' do
+      it 'includes the custom context in the query payload' do
+        query.with_context(maxScatterGatherBytes: 1_000_000, timeout: 30_000).result
+
+        expect(Oj).to have_received(:dump).with(
+          hash_including(
+            context: hash_including(
+              maxScatterGatherBytes: 1_000_000,
+              timeout: 30_000
+            )
+          ),
+          mode: :strict
+        )
+      end
+
+      it 'converts string keys to symbols' do
+        query.with_context('maxScatterGatherBytes' => 1_000_000).result
+
+        expect(Oj).to have_received(:dump).with(
+          hash_including(
+            context: hash_including(maxScatterGatherBytes: 1_000_000)
+          ),
+          mode: :strict
+        )
+      end
+
+      it 'allows chaining' do
+        result_query = query.with_context(foo: 1).with_context(bar: 2)
+
+        expect(result_query).to eq(query)
+      end
+
+      it 'merges multiple with_context calls' do
+        query.with_context(foo: 1).with_context(bar: 2).result
+
+        expect(Oj).to have_received(:dump).with(
+          hash_including(
+            context: hash_including(foo: 1, bar: 2)
+          ),
+          mode: :strict
+        )
+      end
+
+      it 'allows later with_context calls to override earlier ones' do
+        query.with_context(foo: 1).with_context(foo: 2).result
+
+        expect(Oj).to have_received(:dump).with(
+          hash_including(
+            context: hash_including(foo: 2)
+          ),
+          mode: :strict
+        )
+      end
+
+      it 'handles empty hash without error' do
+        query.with_context({}).result
+
+        expect(Oj).to have_received(:dump).with(
+          hash_including(
+            context: hash_including(sqlQueryId: String)
+          ),
+          mode: :strict
+        )
+      end
+    end
+
+    context 'when with_context attempts to override other with_* methods' do
+      it 'built-in with_cache takes precedence over with_context' do
+        query.with_cache.with_context(useCache: false).result
+
+        expect(Oj).to have_received(:dump).with(
+          hash_including(
+            context: hash_including(useCache: true)
+          ),
+          mode: :strict
+        )
+      end
+
+      it 'built-in with_approximate_count_distinct takes precedence over with_context' do
+        query.with_approximate_count_distinct.with_context(useApproximateCountDistinct: false).result
+
+        expect(Oj).to have_received(:dump).with(
+          hash_including(
+            context: hash_including(useApproximateCountDistinct: true)
+          ),
+          mode: :strict
+        )
+      end
+
+      it 'built-in in_time_zone takes precedence over with_context' do
+        query.in_time_zone('America/Los_Angeles').with_context(sqlTimeZone: 'UTC').result
+
+        expect(Oj).to have_received(:dump).with(
+          hash_including(
+            context: hash_including(sqlTimeZone: 'America/Los_Angeles')
+          ),
+          mode: :strict
+        )
+      end
+
+      it 'built-in with_priority takes precedence over with_context' do
+        query.with_priority(10).with_context(priority: 5).result
+
+        expect(Oj).to have_received(:dump).with(
+          hash_including(
+            context: hash_including(priority: 10)
+          ),
+          mode: :strict
+        )
+      end
+
+      it 'built-in with_windowing takes precedence over with_context' do
+        query.with_windowing.with_context(enableWindowing: false).result
+
+        expect(Oj).to have_received(:dump).with(
+          hash_including(
+            context: hash_including(enableWindowing: true)
+          ),
+          mode: :strict
+        )
+      end
+    end
+
+    context 'when other with_* methods override with_context' do
+      it 'allows with_cache to override with_context' do
+        query.with_context(useCache: false).with_cache.result
+
+        expect(Oj).to have_received(:dump).with(
+          hash_including(
+            context: hash_including(useCache: true)
+          ),
+          mode: :strict
+        )
+      end
+
+      it 'allows without_cache to override with_context' do
+        query.with_context(useCache: true).without_cache.result
+
+        expect(Oj).to have_received(:dump).with(
+          hash_including(
+            context: hash_including(useCache: false)
+          ),
+          mode: :strict
+        )
+      end
+
+      it 'allows with_approximate_top_n to override with_context' do
+        query.with_context(useApproximateTopN: false).with_approximate_top_n.result
+
+        expect(Oj).to have_received(:dump).with(
+          hash_including(
+            context: hash_including(useApproximateTopN: true)
+          ),
+          mode: :strict
+        )
+      end
+
+      it 'allows in_time_zone to override with_context' do
+        query.with_context(sqlTimeZone: 'UTC').in_time_zone('America/New_York').result
+
+        expect(Oj).to have_received(:dump).with(
+          hash_including(
+            context: hash_including(sqlTimeZone: 'America/New_York')
+          ),
+          mode: :strict
+        )
+      end
+
+      it 'allows with_priority to override with_context' do
+        query.with_context(priority: 5).with_priority(10).result
+
+        expect(Oj).to have_received(:dump).with(
+          hash_including(
+            context: hash_including(priority: 10)
+          ),
+          mode: :strict
+        )
+      end
+
+      it 'allows without_windowing to override with_context' do
+        query.with_context(enableWindowing: true).without_windowing.result
+
+        expect(Oj).to have_received(:dump).with(
+          hash_including(
+            context: hash_including(enableWindowing: false)
+          ),
+          mode: :strict
+        )
+      end
+    end
+
+    context 'when the query was already executed' do
+      it 'raises an Aganakti::QueryAlreadyExecutedError' do
+        query.result
+
+        expect { query.with_context(foo: 1) }.to raise_error(
+          Aganakti::QueryAlreadyExecutedError,
+          'with_context cannot be set because the query has already been executed'
+        )
+      end
+    end
+
+    context 'when combining with_context and other methods' do
+      it "doesn't affect unrelated context parameters" do
+        query.with_context(customParam: 'value').with_cache.result
+
+        expect(Oj).to have_received(:dump).with(
+          hash_including(
+            context: hash_including(
+              customParam: 'value',
+              useCache: true
+            )
+          ),
+          mode: :strict
+        )
+      end
+
+      it 'allows complex chaining scenarios' do
+        query
+          .with_cache
+          .with_context(customParam: 'initial')
+          .with_priority(5)
+          .with_context(anotherParam: 'value')
+          .in_time_zone('America/Los_Angeles')
+          .result
+
+        expect(Oj).to have_received(:dump).with(
+          hash_including(
+            context: hash_including(
+              customParam: 'initial',
+              anotherParam: 'value',
+              useCache: true,
+              priority: 5,
+              sqlTimeZone: 'America/Los_Angeles'
+            )
+          ),
+          mode: :strict
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Changes
  1. **Added `with_context(context_hash)` method** to `Query` class (lib/aganakti/query.rb:122-145)
     - Accepts a hash of arbitrary context parameters
     - Converts string keys to symbols for consistency
     - Returns `self` for method chaining
     - Raises `QueryAlreadyExecutedError` if called after query execution

  2. **Added `@custom_context` instance variable** initialized to empty hash
     - Stores custom context parameters separately from built-in settings

  3. **Updated `query_context` method** in `Query::Building` module (lib/aganakti/query/building.rb:21-33)
     - Merges `@custom_context` with built-in context parameters
     - Built-in parameters **always take precedence** over custom context

  4. **Fixed initialization bug**: Added missing `@windowing` initialization to prevent nil errors

  ###  Precedence Order

  Built-in methods (`with_cache`, `with_priority`, etc.) **always override** values set by `with_context`. This design ensures:

## Dependencies
Bump stub_server from 0.5.0 to 0.7.0 Fixes compatibility with Rack 3.0+ which removed Rack::Handler. The newer version uses the rackup gem instead.