### PR TITLE
Add query cancellation support and metadata exposure

### DIFF
--- a/lib/aganakti.rb
+++ b/lib/aganakti.rb
@@ -59,6 +59,29 @@ module Aganakti
   class QueryError < Error; end
 
   ##
+  # The query was interrupted by Druid. Check +error_code+ or use +cancelled?+ / +timeout?+
+  # to determine the specific cause.
+  class QueryInterruptedError < Error
+    # @return [String, nil] the Druid error code (e.g., "Query cancelled", "Query timeout")
+    attr_reader :error_code
+
+    def initialize(message, error_code: nil)
+      super(message)
+      @error_code = error_code
+    end
+
+    # @return [Boolean] true if the query was cancelled by a user via DELETE
+    def cancelled?
+      error_code == 'Query cancelled'
+    end
+
+    # @return [Boolean] true if the query timed out
+    def timeout?
+      error_code == 'Query timeout'
+    end
+  end
+
+  ##
   # Creates a new client instance.
   #
   # @param uri [String] the URI of the Druid SQL service, including username and password if applicable

--- a/lib/aganakti/client.rb
+++ b/lib/aganakti/client.rb
@@ -125,5 +125,23 @@ module Aganakti
       Query.new(self, sql, params)
     end
     alias ᏥᏔᏲᎯᎭ query # rubocop:disable Naming/AsciiIdentifiers
+
+    ##
+    # Cancels a running query on the Druid server.
+    #
+    # @param query_id [String] the +sqlQueryId+ of the query to cancel
+    # @return [true] if the cancellation was accepted by the server
+    # @raise [Aganakti::QueryError] if the server returned an error
+    def cancel_query(query_id)
+      cancel_uri = "#{@uri}#{query_id}"
+
+      @instrumenter.instrument('cancel.aganakti', query_id: query_id) do
+        resp = Typhoeus::Request.new(cancel_uri, @typhoeus_options.merge(method: :delete)).run
+
+        return true if resp.code == 202 || resp.code == 404
+
+        raise QueryError, "Failed to cancel query #{query_id}: HTTP #{resp.code}"
+      end
+    end
   end
 end

--- a/lib/aganakti/log_subscriber.rb
+++ b/lib/aganakti/log_subscriber.rb
@@ -26,6 +26,19 @@ module Aganakti
       debug "  #{color(name, MAGENTA, true)}  #{color(sql, BLUE, true)}#{context}#{binds}"
     end
 
+    ##
+    # Called by ActiveSupport notifications when a query cancellation is attempted
+    #
+    # @param event [ActiveSupport::Notifications::Event] the aganakti.cancel event that was triggered
+    def cancel(event)
+      return unless logger.debug?
+
+      query_id = event.payload[:query_id]
+      name     = "Druid SQL Cancel (#{event.duration.round(1)}ms)"
+
+      debug "  #{color(name, RED, true)}  #{color(query_id, BLUE, true)}"
+    end
+
     private
 
     ##

--- a/lib/aganakti/query.rb
+++ b/lib/aganakti/query.rb
@@ -32,6 +32,14 @@ module Aganakti
     private_constant :WITH_WITHOUT_PREFIX
 
     ##
+    # @return [String] the SQL query ID used by Druid to identify this query, usable for cancellation
+    attr_reader :query_id
+
+    ##
+    # @return [Hash, nil] metadata about the query execution, available after the query has been executed
+    attr_reader :metadata
+
+    ##
     # Creates a new Query instance. This is meant to be called by {Aganakti::Client#query}, not directly.
     #
     # @param client [Aganakti::Client] The client
@@ -43,6 +51,8 @@ module Aganakti
       @sql      = sql
       @params   = params
       @qid      = SecureRandom.uuid
+      @query_id = @qid
+      @metadata = nil
 
       # Initialize SQL context options
       @approximate_count_distinct = nil
@@ -78,8 +88,13 @@ module Aganakti
         resp = Typhoeus::Request.new(@client.uri, @client.typhoeus_options.merge(method: :post, body: payload)).run
 
         ResultParser.validate_response!(resp)
-        ResultParser.parse_response(resp).tap do |_|
+        ResultParser.parse_response(resp).tap do |parsed|
           @executed = true
+          @metadata = {
+            total_time_ms:           (resp.total_time * 1000).round(2),
+            time_to_first_byte_ms:   (resp.starttransfer_time * 1000).round(2),
+            response_size_bytes:     resp.body.bytesize
+          }.freeze
         end
       end
     end
@@ -97,6 +112,22 @@ module Aganakti
       raise QueryAlreadyExecutedError, 'in_time_zone cannot be set because the query has already been executed' if executed?
 
       @time_zone = zone
+
+      self
+    end
+
+    ##
+    # Sets a custom SQL query ID for this query. This ID is used by Druid to identify the query
+    # and is required for cancellation. If not set, a random UUID is generated automatically.
+    #
+    # @param id [String] the query ID to use
+    # @return [self] this instance, for chaining
+    # @raise [Aganakti::QueryAlreadyExecutedError] if the query has already been executed
+    def with_query_id(id)
+      raise QueryAlreadyExecutedError, 'with_query_id cannot be set because the query has already been executed' if executed?
+
+      @qid      = id
+      @query_id = id
 
       self
     end

--- a/lib/aganakti/query/result_parser.rb
+++ b/lib/aganakti/query/result_parser.rb
@@ -42,7 +42,11 @@ module Aganakti
           raise QueryTimedOutError if resp.timed_out?
           raise QueryError, "cURL error #{Ethon::Curl.easy_codes.index(resp.return_code)}: #{resp.return_message}" if resp_code.zero?
 
-          raise QueryError, parse_query_error(resp.body)
+          error_msg = parse_query_error(resp.body)
+          error_code = parse_error_code(resp.body)
+          raise QueryInterruptedError.new(error_msg, error_code: error_code) if query_interrupted?(resp.body)
+
+          raise QueryError, error_msg
         end
 
         private
@@ -65,6 +69,30 @@ module Aganakti
           end
 
           error_msg
+        end
+
+        ##
+        # Determines if the error response indicates the query was interrupted by Druid
+        #
+        # @param body [String] the response body
+        # @return [Boolean] true if the query was interrupted
+        def query_interrupted?(body)
+          error_info = Oj.load(body, mode: :strict)
+          error_info['errorClass'].to_s.include?('QueryInterruptedException')
+        rescue Oj::ParseError
+          false
+        end
+
+        ##
+        # Extracts the Druid error code from the response body
+        #
+        # @param body [String] the response body
+        # @return [String, nil] the error code
+        def parse_error_code(body)
+          error_info = Oj.load(body, mode: :strict)
+          error_info['error']
+        rescue Oj::ParseError
+          nil
         end
       end
     end

--- a/lib/aganakti/version.rb
+++ b/lib/aganakti/version.rb
@@ -2,5 +2,5 @@
 
 module Aganakti
   # The version number.
-  VERSION = '1.2.0'
+  VERSION = '1.3.0'
 end

--- a/spec/lib/aganakti/client_spec.rb
+++ b/spec/lib/aganakti/client_spec.rb
@@ -187,4 +187,53 @@ RSpec.describe Aganakti::Client do
       expect(Aganakti::Query).to have_received(:new).with(client, 'SELECT foo FROM datasource WHERE bar = ? AND baz = ?', [42, 'Testing'])
     end
   end
+
+  describe '#cancel_query' do
+    subject(:client) { described_class.new('http://localhost/druid/v2/sql/', {}) }
+
+    let(:query_id) { SecureRandom.uuid }
+    let(:request)  { instance_double(Typhoeus::Request) }
+    let(:response) { instance_double(Typhoeus::Response) }
+
+    before do
+      allow(Typhoeus::Request).to receive(:new).and_return(request)
+      allow(request).to receive(:run).and_return(response)
+    end
+
+    context 'when Druid accepts the cancellation (202)' do
+      before { allow(response).to receive(:code).and_return(202) }
+
+      it 'returns true' do
+        expect(client.cancel_query(query_id)).to be true
+      end
+
+      it 'sends a DELETE request to the correct URI' do
+        client.cancel_query(query_id)
+
+        expect(Typhoeus::Request).to have_received(:new).with(
+          "http://localhost/druid/v2/sql/#{query_id}",
+          hash_including(method: :delete)
+        )
+      end
+    end
+
+    context 'when the query already finished (404)' do
+      before { allow(response).to receive(:code).and_return(404) }
+
+      it 'returns true' do
+        expect(client.cancel_query(query_id)).to be true
+      end
+    end
+
+    context 'when Druid returns an unexpected error' do
+      before { allow(response).to receive(:code).and_return(500) }
+
+      it 'raises a QueryError' do
+        expect { client.cancel_query(query_id) }.to raise_error(
+          Aganakti::QueryError,
+          "Failed to cancel query #{query_id}: HTTP 500"
+        )
+      end
+    end
+  end
 end

--- a/spec/lib/aganakti/query_spec.rb
+++ b/spec/lib/aganakti/query_spec.rb
@@ -164,6 +164,11 @@ RSpec.describe Aganakti::Query do
       RESPONSE
     end
 
+    let(:cancelled_response) do
+      '{"error":"Query cancelled","errorMessage":"Query cancelled by user",' \
+      '"errorClass":"org.apache.druid.query.QueryInterruptedException","host":null}'
+    end
+
     # Standard response headers that all requests return
     let(:response_headers) do
       {
@@ -178,6 +183,7 @@ RSpec.describe Aganakti::Query do
         '/error' => [400, response_headers, [error_response]],
         '/error2' => [500, {}, ['Internal Server Error']],
         '/error3' => [500, response_headers, ['{"problem":true}']],
+        '/cancelled' => [500, response_headers, [cancelled_response]],
         '/timeout' => [200, response_headers, timeout_response.first],
         '/truncated' => [200, response_headers, [truncated_response]]
       }
@@ -255,6 +261,19 @@ RSpec.describe Aganakti::Query do
 
           expect { live_query.to_a }.to raise_error(Aganakti::QueryError, 'Plan validation failed: org.apache.calcite.runtime.CalciteContextException: ' \
                                                                           'At line 1, column 77: Ordinal out of range')
+        end
+      end
+
+      it 'handles cancelled queries' do
+        with_stub_server(replies) do |port|
+          client     = Aganakti.new("http://localhost:#{port}/cancelled")
+          live_query = query.call(client)
+
+          expect { live_query.to_a }.to raise_error(Aganakti::QueryInterruptedError, 'Query cancelled: Query cancelled by user') do |error|
+            expect(error.error_code).to eq('Query cancelled')
+            expect(error).to be_cancelled
+            expect(error).not_to be_timeout
+          end
         end
       end
 
@@ -418,6 +437,67 @@ RSpec.describe Aganakti::Query do
       it 'is properly identified as existing via #respond_to?' do
         expect(query).to respond_to(del.to_sym)
       end
+    end
+  end
+
+  describe '#query_id', :stubbed_request do
+    it 'returns the auto-generated UUID' do
+      expect(query.query_id).to match(/\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/)
+    end
+
+    it 'matches the sqlQueryId sent to Druid' do
+      allow(Oj).to receive(:dump).and_call_original.once
+
+      query.result
+
+      expect(Oj).to have_received(:dump).with(
+        hash_including(context: hash_including(sqlQueryId: query.query_id)),
+        mode: :strict
+      )
+    end
+  end
+
+  describe '#with_query_id', :stubbed_request do
+    let(:custom_id) { SecureRandom.uuid }
+
+    before do
+      allow(Oj).to receive(:dump).and_call_original.once
+    end
+
+    it 'overrides the auto-generated query ID' do
+      query.with_query_id(custom_id)
+
+      expect(query.query_id).to eq(custom_id)
+    end
+
+    it 'sets the custom ID as sqlQueryId in the query context' do
+      query.with_query_id(custom_id).result
+
+      expect(Oj).to have_received(:dump).with(
+        hash_including(context: hash_including(sqlQueryId: custom_id)),
+        mode: :strict
+      )
+    end
+
+    it 'returns self for chaining' do
+      expect(query.with_query_id(custom_id)).to eq(query)
+    end
+
+    context 'when the query was already executed' do
+      it 'raises an Aganakti::QueryAlreadyExecutedError' do
+        query.result
+
+        expect { query.with_query_id(custom_id) }.to raise_error(
+          Aganakti::QueryAlreadyExecutedError,
+          'with_query_id cannot be set because the query has already been executed'
+        )
+      end
+    end
+  end
+
+  describe '#metadata', :stubbed_request do
+    it 'is nil before execution' do
+      expect(query.metadata).to be_nil
     end
   end
 

--- a/spec/lib/aganakti_spec.rb
+++ b/spec/lib/aganakti_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Aganakti do
   end
 
   %i[
-    ConfigurationError IllegalEscapeError QueryAlreadyExecutedError QueryResultTruncatedError
+    ConfigurationError IllegalEscapeError QueryAlreadyExecutedError QueryInterruptedError QueryResultTruncatedError
     QueryResultUnparseableError QueryTimedOutError QueryError
   ].each do |err|
     describe "::#{err}" do

--- a/spec/support/shared_contexts.rb
+++ b/spec/support/shared_contexts.rb
@@ -11,9 +11,9 @@ RSpec.shared_context 'with a stubbed request and response', :stubbed_request do
 
   let(:client)           { instance_double(Aganakti::Client, instrumenter: instrumenter, typhoeus_options: typhoeus_options, uri: uri) }
   let(:instrumenter)     { instance_double(ActiveSupport::Notifications::Instrumenter) }
-  let(:result)           { instance_double(ActiveRecord::Result) }
+  let(:result)           { instance_double(ActiveRecord::Result, rows: []) }
   let(:request)          { instance_double(Typhoeus::Request) }
-  let(:response)         { instance_double(Typhoeus::Response) }
+  let(:response)         { instance_double(Typhoeus::Response, total_time: 0.15, starttransfer_time: 0.1, body: '[]') }
   let(:typhoeus_options) { { headers: { 'Accept' => 'application/json', 'Content-Type' => 'application/json' } } }
   let(:uri)              { 'http://localhost' }
 


### PR DESCRIPTION
- Add QueryCancelledError for distinguishing cancelled queries
- Add Client#cancel_query to send DELETE to Druid SQL API
- Expose Query#query_id for tracking in-flight queries
- Expose Query#metadata with timing and size info after execution
- Detect Druid cancellation responses in ResultParser