### PR TITLE
Add ability for imply responses to regnonize cancellation

### DIFF
--- a/lib/aganakti/query/result_parser.rb
+++ b/lib/aganakti/query/result_parser.rb
@@ -78,7 +78,9 @@ module Aganakti
         # @return [Boolean] true if the query was interrupted
         def query_interrupted?(body)
           error_info = Oj.load(body, mode: :strict)
-          error_info['errorClass'].to_s.include?('QueryInterruptedException')
+          error_class = error_info['errorClass'].to_s
+          error_class.include?('QueryInterruptedException') ||
+            error_class.include?('CancellationException')
         rescue Oj::ParseError
           false
         end

--- a/spec/lib/aganakti/query_spec.rb
+++ b/spec/lib/aganakti/query_spec.rb
@@ -169,6 +169,11 @@ RSpec.describe Aganakti::Query do
       '"errorClass":"org.apache.druid.query.QueryInterruptedException","host":null}'
     end
 
+    let(:delete_cancelled_response) do
+      '{"error":"Query cancelled","errorMessage":"Task was cancelled.",' \
+      '"errorClass":"java.util.concurrent.CancellationException","host":null}'
+    end
+
     # Standard response headers that all requests return
     let(:response_headers) do
       {
@@ -184,6 +189,7 @@ RSpec.describe Aganakti::Query do
         '/error2' => [500, {}, ['Internal Server Error']],
         '/error3' => [500, response_headers, ['{"problem":true}']],
         '/cancelled' => [500, response_headers, [cancelled_response]],
+        '/delete_cancelled' => [500, response_headers, [delete_cancelled_response]],
         '/timeout' => [200, response_headers, timeout_response.first],
         '/truncated' => [200, response_headers, [truncated_response]]
       }
@@ -270,6 +276,19 @@ RSpec.describe Aganakti::Query do
           live_query = query.call(client)
 
           expect { live_query.to_a }.to raise_error(Aganakti::QueryInterruptedError, 'Query cancelled: Query cancelled by user') do |error|
+            expect(error.error_code).to eq('Query cancelled')
+            expect(error).to be_cancelled
+            expect(error).not_to be_timeout
+          end
+        end
+      end
+
+      it 'handles queries cancelled via DELETE (CancellationException)' do
+        with_stub_server(replies) do |port|
+          client     = Aganakti.new("http://localhost:#{port}/delete_cancelled")
+          live_query = query.call(client)
+
+          expect { live_query.to_a }.to raise_error(Aganakti::QueryInterruptedError, 'Query cancelled: Task was cancelled.') do |error|
             expect(error.error_code).to eq('Query cancelled')
             expect(error).to be_cancelled
             expect(error).not_to be_timeout


### PR DESCRIPTION
## Fix: Recognize CancellationException as a query interruption



When Druid returns the cancellation error, aganakti's validate_response! runs:

```ruby
# result_parser.rb  

This is from ProcessReportQueryWorker which is waiting for query to finish 

def validate_response!(resp)
  resp_code = resp.code
  return if resp_code == 200          # ← not 200, Druid returned an error because the query got cancelled.

  raise QueryTimedOutError if resp.timed_out?   # ← no
  raise QueryError, "..." if resp_code.zero?    # ← no

  error_msg = parse_query_error(resp.body)      # → "Query cancelled: Task was cancelled."
  error_code = parse_error_code(resp.body)      # → "Query cancelled"

  raise QueryInterruptedError.new(error_msg, error_code: error_code) if query_interrupted?(resp.body)
  #     ↑ THIS is what we WANT to raise
  #     but query_interrupted? returns FALSE because errorClass is
  #     "java.util.concurrent.CancellationException", not "QueryInterruptedException"

  raise QueryError, error_msg
  #     ↑ THIS is what actually gets raised
end
```


So aganakti raises Aganakti::QueryError. Now in ProcessReportQueryWorker:

```ruby
def safe_perform(report_query_id, options = {})
  # ...
  process!                                          # ← Aganakti::QueryError raised here

rescue Aganakti::QueryInterruptedError => e         # ← SKIP. It's QueryError, not QueryInterruptedError
  # never reaches here

rescue StandardError => e                           # ← CATCHES HERE (QueryError < Error < StandardError)
  update_report_query_to_failed_state(e)            # ← sets status to "failed"
  raise e                                           # ← re-raises → Sidekiq counts it as failure
end
```



With the aganakti fix, query_interrupted? would return true, so validate_response! would raise QueryInterruptedError instead. Then:



```ruby
rescue Aganakti::QueryInterruptedError => e         # ← NOW MATCHES
  if e.cancelled?                                   # ← e.error_code == "Query cancelled" → true
    update_report_query_to_cancelled_state(e)       # ← sets status to "cancelled" ✓
  end
  # no raise → Sidekiq sees it as success ✓

```

### Fix

query_interrupted? now also checks for CancellationException in the errorClass field, consistent with the existing substring matching pattern.


```ruby
        def query_interrupted?(body)
          error_info = Oj.load(body, mode: :strict)
          error_class = error_info['errorClass'].to_s
          error_class.include?('QueryInterruptedException') || **error_class.include?('CancellationException')** <- Added
```