### PR TITLE
Bump version to 1.3.1

### DIFF
--- a/lib/aganakti/version.rb
+++ b/lib/aganakti/version.rb
@@ -2,5 +2,5 @@
 
 module Aganakti
   # The version number.
-  VERSION = '1.3.0'
+  VERSION = '1.3.1'
 end


### PR DESCRIPTION
 **Bump version to 1.3.1**

 Release 1.3.1 includes the fix for recognizing CancellationException as a query interruption when queries are cancelled via DELETE /druid/v2/sql/{sqlQueryId}.