### PR TITLE
Recognize Sequence canceled as a query cancellation

### DIFF
--- a/lib/aganakti.rb
+++ b/lib/aganakti.rb
@@ -72,7 +72,7 @@ module Aganakti
 
     # @return [Boolean] true if the query was cancelled by a user via DELETE
     def cancelled?
-      error_code == 'Query cancelled'
+      error_code == 'Query cancelled' || message.to_s.downcase.then { |m| m.include?('canceled') || m.include?('cancelled') }
     end
 
     # @return [Boolean] true if the query timed out

--- a/lib/aganakti/query/result_parser.rb
+++ b/lib/aganakti/query/result_parser.rb
@@ -80,7 +80,8 @@ module Aganakti
           error_info = Oj.load(body, mode: :strict)
           error_class = error_info['errorClass'].to_s
           error_class.include?('QueryInterruptedException') ||
-            error_class.include?('CancellationException')
+            error_class.include?('CancellationException') ||
+            error_info['errorMessage'].to_s.downcase.then { |m| m.include?('canceled') || m.include?('cancelled') }
         rescue Oj::ParseError
           false
         end

--- a/lib/aganakti/version.rb
+++ b/lib/aganakti/version.rb
@@ -2,5 +2,5 @@
 
 module Aganakti
   # The version number.
-  VERSION = '1.3.1'
+  VERSION = '1.3.2'
 end

--- a/spec/lib/aganakti/query_spec.rb
+++ b/spec/lib/aganakti/query_spec.rb
@@ -174,6 +174,11 @@ RSpec.describe Aganakti::Query do
       '"errorClass":"java.util.concurrent.CancellationException","host":null}'
     end
 
+    let(:sequence_cancelled_response) do
+      '{"error":"Unknown exception","errorMessage":"Sequence canceled",' \
+      '"errorClass":"org.apache.druid.error.DruidException","host":null}'
+    end
+
     # Standard response headers that all requests return
     let(:response_headers) do
       {
@@ -190,6 +195,7 @@ RSpec.describe Aganakti::Query do
         '/error3' => [500, response_headers, ['{"problem":true}']],
         '/cancelled' => [500, response_headers, [cancelled_response]],
         '/delete_cancelled' => [500, response_headers, [delete_cancelled_response]],
+        '/sequence_cancelled' => [500, response_headers, [sequence_cancelled_response]],
         '/timeout' => [200, response_headers, timeout_response.first],
         '/truncated' => [200, response_headers, [truncated_response]]
       }
@@ -290,6 +296,19 @@ RSpec.describe Aganakti::Query do
 
           expect { live_query.to_a }.to raise_error(Aganakti::QueryInterruptedError, 'Query cancelled: Task was cancelled.') do |error|
             expect(error.error_code).to eq('Query cancelled')
+            expect(error).to be_cancelled
+            expect(error).not_to be_timeout
+          end
+        end
+      end
+
+      it 'handles queries cancelled via DELETE (Sequence canceled)' do
+        with_stub_server(replies) do |port|
+          client     = Aganakti.new("http://localhost:#{port}/sequence_cancelled")
+          live_query = query.call(client)
+
+          expect { live_query.to_a }.to raise_error(Aganakti::QueryInterruptedError, 'Unknown exception: Sequence canceled') do |error|
+            expect(error.error_code).to eq('Unknown exception')
             expect(error).to be_cancelled
             expect(error).not_to be_timeout
           end


### PR DESCRIPTION
Apart from seeing Canceallaiton Exception like in https://github.com/art19/aganakti/pull/9
Example : 
```

QueryInterruptedException{msg=Task was cancelled., code=Query cancelled, class=java.util.concurrent.CancellationException}
org.apache.druid.error.DruidException: Task was cancelled.
```

Also seeing durid thow Runtime exception 👇 
``` 
 java.lang.RuntimeException: Sequence canceled
   org.apache.druid.error.DruidException: Sequence canceled

```


Handling this as a cancelled request.


Additionally exception message can contain both variations  : cancelled or canceled 

Druid source code has a comment that since its also in docs that its not going to cleaned up.